### PR TITLE
docs: add documentation about how to use and available options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This will install any necessary packages for the project.
 
 ## Usage
 
-Currently, the project does not actually expose any function or interface to use... TBD
+For detailed usage instructions, refer to the [Usage Documentation](docs/usage.md).
 
 ## Testing
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,50 @@
+# Grawlr Usage Documentation
+
+Grawlr is a web crawling library written in Go. This document provides an overview of how to use Grawlr, including examples and configuration options.
+
+## Examples
+
+The `_examples` directory contains sample implementations to help you get started with Grawlr. Below are some examples:
+
+- [Basic Example](../_examples/basic_example.go): Demonstrates a simple web crawling setup.
+- [Maximum Depth Example](../_examples/maximum_depth.go): Shows how to configure and use the depth limit feature.
+
+To run an example, navigate to the `_examples` directory and execute the file:
+
+```bash
+cd _examples
+go run basic_example.go
+```
+
+## Configuration Options
+
+Grawlr provides several configuration options to customize its behavior. These options can be set using functional options when creating a new `Harvester` instance.
+
+| Option               | Description                                                                                     | Default Value |
+|----------------------|-------------------------------------------------------------------------------------------------|---------------|
+| `WithClient`         | Sets a custom `http.Client` for the harvester.                                                  | `http.DefaultClient` |
+| `WithAllowedURLs`    | Specifies a list of URLs that are allowed to be fetched.                                        | `[]` (no restrictions) |
+| `WithDisallowedURLs` | Specifies a list of URLs that are disallowed from being fetched.                                | `[]` (no restrictions) |
+| `WithDepthLimit`     | Sets the maximum depth of links to follow. A value of `0` means no limit.                       | `0` (no limit) |
+| `WithAllowRevisit`   | Allows revisiting URLs even if they have already been visited.                                  | `false` |
+| `WithContext`        | Sets a custom `context.Context` for managing request lifetimes.                                 | `context.Background()` |
+| `WithStore`          | Sets a custom `Storer` implementation for caching visited URLs.                                | In-memory store |
+| `WithIgnoreRobots`   | Ignores `robots.txt` rules when set to `true`.                                                  | `false` |
+
+### Example: Configuring a Harvester
+
+Below is an example of how to configure a `Harvester` with custom options:
+
+```go
+h := grawlr.NewHarvester(
+    grawlr.WithAllowedURLs([]string{"https://example.com"}),
+    grawlr.WithDisallowedURLs([]string{"https://example.com/private"}),
+    grawlr.WithDepthLimit(2),
+    grawlr.WithAllowRevisit(false),
+    grawlr.WithIgnoreRobots(true),
+)
+```
+
+## Additional Resources
+
+For more details, refer to the [README.md](../README.md) file or explore the source code in this repository.


### PR DESCRIPTION
This pull request introduces a new usage documentation for the Grawlr web crawling library. The documentation includes examples, configuration options, and additional resources to help users get started with Grawlr.

Key changes include:

* [`docs/usage.md`](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R1-R50): Added a comprehensive usage guide for Grawlr, including examples of basic usage and configuration options. The guide covers how to run examples, set various configuration options, and provides a sample configuration for a `Harvester` instance.